### PR TITLE
Add example of WebWorker and ShadowDOM

### DIFF
--- a/webworker-shadowdom/.gitignore
+++ b/webworker-shadowdom/.gitignore
@@ -1,0 +1,4 @@
+*.min.worker.js
+*.min.js
+*.map
+package-lock.json

--- a/webworker-shadowdom/index.html
+++ b/webworker-shadowdom/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+    <script type="module" src="index.min.js"></script>
+</head>
+<body>
+    <p>This is an inline-math formula <span is="inline-math">a^2+b^2=c^2</span>. This is a display-math formula.</p>
+    <div is="display-math">3^2+4^2=5^2</div>
+</body>
+</html>

--- a/webworker-shadowdom/index.js
+++ b/webworker-shadowdom/index.js
@@ -1,0 +1,27 @@
+class InlineMath extends HTMLSpanElement {
+    constructor() {
+        super();
+        const shadow = this.attachShadow({ mode: "closed" });
+        const worker = new Worker("./worker", { type: "module" });
+        worker.onmessage = (event) => {
+            shadow.innerHTML = event.data;
+        };
+        worker.postMessage({ math: this.innerHTML, display: false });
+    }
+}
+
+customElements.define("inline-math", InlineMath, { extends: "span" });
+
+class DisplayMath extends HTMLDivElement {
+    constructor() {
+        super();
+        const shadow = this.attachShadow({ mode: "closed" });
+        const worker = new Worker("./worker", { type: "module" });
+        worker.onmessage = (event) => {
+            shadow.innerHTML = event.data;
+        };
+        worker.postMessage({ math: this.innerHTML, display: true });
+    }
+}
+
+customElements.define("display-math", DisplayMath, { extends: "div" });

--- a/webworker-shadowdom/package.json
+++ b/webworker-shadowdom/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "webworker-shadowdom",
+  "version": "0.1.0",
+  "description": "Example project for MathJaX 3 with WebWorker and ShadowDOM",
+  "main": "index.js",
+  "scripts": {
+    "build": "webpack"
+  },
+  "keywords": [
+    "mathjax"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "mathjax-full": "^3.0.0",
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.10",
+    "worker-plugin": "^3.2.0"
+  }
+}

--- a/webworker-shadowdom/webpack.config.js
+++ b/webworker-shadowdom/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+    entry: {
+        index: "./index.js"
+    },
+    output: {
+        path: __dirname,
+        filename: "[name].min.js"
+    },
+    plugins: [new (require("worker-plugin"))()],
+    devtool: "sourcemap"
+}

--- a/webworker-shadowdom/worker.js
+++ b/webworker-shadowdom/worker.js
@@ -1,0 +1,18 @@
+import { mathjax } from "mathjax-full/js/mathjax";
+import { TeX } from "mathjax-full/js/input/tex";
+import { SVG } from "mathjax-full/js/output/svg";
+import { liteAdaptor } from "mathjax-full/js/adaptors/liteAdaptor";
+import { RegisterHTMLHandler } from "mathjax-full/js/handlers/html";
+import { AllPackages } from "mathjax-full/js/input/tex/AllPackages";
+const adaptor = liteAdaptor();
+RegisterHTMLHandler(adaptor);
+const tex = new TeX({ packages: AllPackages });
+const svg = new SVG({ fontCache: "none" });
+const html = mathjax.document("", { InputJax: tex, OutputJax: svg });
+
+self.onmessage = (event) => {
+    self.postMessage(`
+        <style>${adaptor.textContent(svg.styleSheet(html))}</style>
+        ${adaptor.outerHTML(html.convert(event.data.math, { display: event.data.display }))}
+    `);
+};


### PR DESCRIPTION
Now we can use MathJaX3 in WebWorker with liteDOM, and we can also render formula in shadowDOM with SVG. 

- WebWorker renderers formula asynchronously in the thread.
- shadowDOM hides mathjax specific stylesheet against global environment.

This demonstration shows the above usage.

Cheers.